### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/backend/routes/chatgpt.py
+++ b/backend/routes/chatgpt.py
@@ -130,4 +130,4 @@ def suggest_recipes():
 
     except Exception as e:
         logger.error("Error generating recipes: %s", str(e))
-        return jsonify({'error': 'Failed to generate recipes', 'details': str(e)}), 500
+        return jsonify({'error': 'Failed to generate recipes'}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/yes-chef-gpt/security/code-scanning/1](https://github.com/ajharris/yes-chef-gpt/security/code-scanning/1)

To fix this problem, the server should not return the exception details (`str(e)`) to the user. Instead, it should only provide a generic error message in the response, such as "Failed to generate recipes," while logging the full exception details on the server for the developers' reference.

The changes required are:
- In backend/routes/chatgpt.py, within the `except Exception as e:` block, remove `'details': str(e)` from the response.
- Ensure that exception details are still logged server-side via `logger.error`, which is already present.
- No additional imports or method definitions are needed, as logging is already set up.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
